### PR TITLE
Add LICENSE in generated source tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include setup.py
+include LICENSE
 recursive-include docs *.rst *.py *.html *.css *.js *.png *.txt
 recursive-include demoapp *.py
 recursive-include tests *.py


### PR DESCRIPTION
Most distributions require shipping license in source tarballs
